### PR TITLE
Adds support for --exec-root docker daemon option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ The `docker_service` resource property list mostly corresponds to the options fo
 - `dns` - DNS server(s) to use
 - `dns_search` - DNS search domains to use
 - `exec_driver` - Exec driver to use
+- `exec_root` - Directory for Docker's execution state
 - `fixed_cidr` - IPv4 subnet for fixed IPs
 - `fixed_cidr_v6` - IPv6 subnet for fixed IPs
 - `group` - Posix group for the unix socket

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -31,6 +31,7 @@ module DockerCookbook
     property :dns_search, [Array, nil]
     property :exec_driver, ['native', 'lxc', nil]
     property :exec_opts, ArrayType
+    property :exec_root, [String, nil]
     property :fixed_cidr, [String, nil]
     property :fixed_cidr_v6, [String, nil]
     property :group, [String, nil]

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -162,6 +162,7 @@ module DockerCookbook
         dns_search.each { |dns| opts << "--dns-search=#{dns}" } if dns_search
         opts << "--exec-driver=#{exec_driver}" if exec_driver
         exec_opts.each { |exec_opt| opts << "--exec-opt=#{exec_opt}" } if exec_opts
+        opts << "--exec-root=#{exec_root}" if exec_root
         opts << "--fixed-cidr=#{fixed_cidr}" if fixed_cidr
         opts << "--fixed-cidr-v6=#{fixed_cidr_v6}" if fixed_cidr_v6
         opts << "--group=#{group}" if group


### PR DESCRIPTION
@vsco/devops This adds a new option to a chef resource needed for defining a docker service.
